### PR TITLE
Remove ssh support. 

### DIFF
--- a/autoload/unite/sources/grep_git.vim
+++ b/autoload/unite/sources/grep_git.vim
@@ -79,15 +79,6 @@ function! s:source.gather_candidates(args, context) "{{{
       \)
   endif
 
-  if a:context.source__ssh_path != ''
-    " Use ssh command.
-    let [hostname, port] =
-          \ unite#sources#ssh#parse_path(a:context.source__ssh_path)[:1]
-    let cmdline = substitute(substitute(
-          \ g:unite_kind_file_ssh_command . ' ' . cmdline,
-          \   '\<HOSTNAME\>', hostname, 'g'), '\<PORT\>', port, 'g')
-  endif
-
   call unite#print_source_message('Command-line: ' . cmdline, s:source.name)
 
   " Note:


### PR DESCRIPTION
いつもこのプラグインにはお世話になってます。
最近 :NeoBundleInstall! したら下記エラーで動作不能になりました。

```
function <SNR>30_call_unite_empty..unite#start..unite#start#standard..unite#candidates#_recache..<SNR>92_recache_candid
ates_loop..<SNR>92_get_source_candidates..89, line 45                                                                  
Vim(if):E716: Key not present in Dictionary: source__ssh_path != ''                                                    
[unite.vim] Error occurred in gather_candidates!                                                                       
[unite.vim] Source name is grep/git 
```

調べるとUnite.vimでssh supportが外れていたので追従しました
https://github.com/Shougo/unite.vim/commit/cc911a161a92cebe65b118a3fc0c398261040e36
